### PR TITLE
rtph26[45]depay: Don't handle NALs inside STAP units twice (cherry-picked from upstream)

### DIFF
--- a/gst/rtp/gstrtph264depay.c
+++ b/gst/rtp/gstrtph264depay.c
@@ -1055,12 +1055,8 @@ gst_rtp_h264_depay_process (GstRTPBaseDepayload * depayload, GstRTPBuffer * rtp)
         }
 
         outsize = gst_adapter_available (rtph264depay->adapter);
-        if (outsize > 0) {
+        if (outsize > 0)
           outbuf = gst_adapter_take_buffer (rtph264depay->adapter, outsize);
-          outbuf =
-              gst_rtp_h264_depay_handle_nal (rtph264depay, outbuf, timestamp,
-              marker);
-        }
         break;
       }
       case 26:

--- a/gst/rtp/gstrtph265depay.c
+++ b/gst/rtp/gstrtph265depay.c
@@ -1242,12 +1242,8 @@ gst_rtp_h265_depay_process (GstRTPBaseDepayload * depayload, GstRTPBuffer * rtp)
         }
 
         outsize = gst_adapter_available (rtph265depay->adapter);
-        if (outsize > 0) {
+        if (outsize > 0)
           outbuf = gst_adapter_take_buffer (rtph265depay->adapter, outsize);
-          outbuf =
-              gst_rtp_h265_depay_handle_nal (rtph265depay, outbuf, timestamp,
-              marker);
-        }
         break;
       }
       case 49:


### PR DESCRIPTION
Tentative fix for https://github.com/Kurento/bugtracker/issues/352.